### PR TITLE
Use parallel for speeding up

### DIFF
--- a/dashdog.gemspec
+++ b/dashdog.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor", "~> 0.19.1"
   spec.add_dependency "coderay"
   spec.add_dependency "diffy"
+  spec.add_dependency "parallel"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/dashdog/client.rb
+++ b/lib/dashdog/client.rb
@@ -1,4 +1,5 @@
 require 'dogapi'
+require 'parallel'
 
 module Dashdog
   class Client
@@ -9,7 +10,7 @@ module Dashdog
 
     def get_timeboards
       ret = []
-      @api.get_dashboards[1]['dashes'].each do |bd|
+      Parallel.each(@api.get_dashboards[1]['dashes'], in_threads: 8)  do |bd|
         ret << @api.get_dashboard(bd['id'])[1]['dash']
       end
       return ret
@@ -17,7 +18,7 @@ module Dashdog
 
     def get_screenboards
       ret = []
-      @api.get_all_screenboards[1]['screenboards'].each do |bd|
+      Parallel.each(@api.get_all_screenboards[1]['screenboards'], in_threads: 8) do |bd|
         ret << @api.get_screenboard(bd['id'])[1]
       end
       return ret


### PR DESCRIPTION
- without parallel

```
$ time dashdog export | wc -l
    9639

real    0m52.363s
user    0m0.936s
sys     0m0.254s
```
- use parallel

```
$ time dashdog export | wc -l
    9639

real    0m8.955s
user    0m0.964s
sys     0m0.241s
```

Please merge if there is no problem 🙇 
