### PR TITLE
Add color option / check stdout tty

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Commands:
 Options:
   -f, [--file=FILE]  # Configuration file
                      # Default: Boardfile
+      [--color], [--no-color]  # Disable colorize
+                               # Default: true
 ```
 
 ## Commands

--- a/lib/dashdog/actions.rb
+++ b/lib/dashdog/actions.rb
@@ -13,7 +13,7 @@ module Dashdog
     def export(options)
       dsl = @converter.timeboards_to_dsl(@client.get_timeboards)
       dsl << @converter.screenboards_to_dsl(@client.get_screenboards)
-      Dashdog::Utils.print_ruby(dsl)
+      Dashdog::Utils.print_ruby(dsl, color: options[:color])
       File.write(options['file'], dsl) if options['write']
     end
 

--- a/lib/dashdog/cli.rb
+++ b/lib/dashdog/cli.rb
@@ -3,6 +3,7 @@ require 'thor'
 module Dashdog
   class Cli < Thor
     class_option :file, aliases: '-f', desc: 'Configuration file', type: :string, default: 'Boardfile'
+    class_option :color, desc: 'Disable colorize', type: :boolean, default: $stdout.tty?
 
     def initialize(*args)
       @actions = Dashdog::Actions.new

--- a/lib/dashdog/utils.rb
+++ b/lib/dashdog/utils.rb
@@ -20,8 +20,12 @@ module Dashdog
       puts CodeRay.scan(yaml, :yaml).terminal
     end
 
-    def self.print_ruby(ruby)
-      puts CodeRay.scan(ruby, :ruby).terminal
+    def self.print_ruby(ruby, options = {})
+      if options[:color]
+        puts CodeRay.scan(ruby, :ruby).terminal
+      else
+        puts ruby
+      end
     end
 
     def self.print_json(json)


### PR DESCRIPTION
Add `--color` option, and set default value from `$stdout.tty?`
( Disable colorize when `dashdog export > Boardfile`)
