### PR TITLE
Support template

### DIFF
--- a/dashdog.gemspec
+++ b/dashdog.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "coderay"
   spec.add_dependency "diffy"
   spec.add_dependency "parallel"
+  spec.add_dependency "hashie"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/dashdog.gemspec
+++ b/dashdog.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "dogapi"
-  spec.add_dependency "dslh", "~> 0.3.8"
+  spec.add_dependency "dslh", "~> 0.3.9"
   spec.add_dependency "thor", "~> 0.19.1"
   spec.add_dependency "coderay"
   spec.add_dependency "diffy"

--- a/lib/dashdog.rb
+++ b/lib/dashdog.rb
@@ -6,6 +6,7 @@ require "dashdog/client"
 require "dashdog/converter"
 require "dashdog/actions"
 require "dashdog/cli"
+require "dashdog/dsl_context"
 
 module Dashdog
   # Your code goes here...

--- a/lib/dashdog/converter.rb
+++ b/lib/dashdog/converter.rb
@@ -61,40 +61,8 @@ EOS
     end
 
     def to_h(dsl_file)
-      @_dsl_file = dsl_file
-      instance_eval(File.read(dsl_file), dsl_file)
-      @boards
+      context = DSLContext.new
+      context.eval_dsl(dsl_file)
     end
-
-    private
-
-    def require(file)
-      boardfile = (file =~ %r|\A/|) ? file : File.expand_path(File.join(File.dirname(@_dsl_file), file))
-
-      if File.exist?(boardfile)
-        instance_eval(File.read(boardfile), boardfile)
-      elsif File.exist?(boardfile + '.rb')
-        instance_eval(File.read(boardfile + '.rb'), boardfile + '.rb')
-      else
-        Kernel.require(file)
-      end
-    end
-
-    def timeboard(value = nil, &block)
-      hash = Dslh.eval(
-        allow_empty_args: true,
-        &block)
-      hash['title'] = value
-      @boards['timeboards'] << hash
-    end
-
-    def screenboard(value = nil, &block)
-      hash = Dslh.eval(
-        allow_empty_args: true,
-        &block)
-      hash['board_title'] = value
-      @boards['screenboards'] << hash
-    end
-
   end
 end

--- a/lib/dashdog/dsl_context.rb
+++ b/lib/dashdog/dsl_context.rb
@@ -20,6 +20,10 @@ module Dashdog
       @templates[name.to_s] = block
     end
 
+    def context
+      @context
+    end
+
     def require(file)
       boardfile = (file =~ %r|\A/|) ? file : File.expand_path(File.join(File.dirname(@_dsl_file), file))
 

--- a/lib/dashdog/dsl_context.rb
+++ b/lib/dashdog/dsl_context.rb
@@ -46,7 +46,7 @@ module Dashdog
 
     def dslh_eval(block)
       scope_hook = proc do |scope|
-        scope.instance_eval(<<-EOS)
+        scope.instance_eval(<<-'EOS')
           def include_template(template_name, context = {})
             tmplt = @templates[template_name.to_s]
 

--- a/lib/dashdog/dsl_context.rb
+++ b/lib/dashdog/dsl_context.rb
@@ -1,7 +1,11 @@
+require 'hashie'
+
 module Dashdog
   class DSLContext
     def initialize
       @boards = {'timeboards' => [], 'screenboards' => []}
+      @templates = {}
+      @context = Hashie::Mash.new()
     end
 
     def eval_dsl(dsl_file)
@@ -11,6 +15,10 @@ module Dashdog
     end
 
     private
+
+    def template(name, &block)
+      @templates[name.to_s] = block
+    end
 
     def require(file)
       boardfile = (file =~ %r|\A/|) ? file : File.expand_path(File.join(File.dirname(@_dsl_file), file))
@@ -25,19 +33,42 @@ module Dashdog
     end
 
     def timeboard(value = nil, &block)
-      hash = Dslh.eval(
-        allow_empty_args: true,
-        &block)
+      hash = dslh_eval(block)
       hash['title'] = value
       @boards['timeboards'] << hash
     end
 
     def screenboard(value = nil, &block)
-      hash = Dslh.eval(
-        allow_empty_args: true,
-        &block)
+      hash = dslh_eval(block)
       hash['board_title'] = value
       @boards['screenboards'] << hash
+    end
+
+    def dslh_eval(block)
+      scope_hook = proc do |scope|
+        scope.instance_eval(<<-EOS)
+          def include_template(template_name, context = {})
+            tmplt = @templates[template_name.to_s]
+
+            unless tmplt
+              raise "Template '#{template_name}' is not defined"
+            end
+
+            context_orig = @context
+            @context = @context.merge(context)
+            instance_eval(&tmplt)
+            @context = context_orig
+          end
+
+          def context
+            @context
+          end
+        EOS
+      end
+
+      scope_vars = {templates: @templates, context: @context}
+
+      Dslh.eval(allow_empty_args: true, scope_hook: scope_hook, scope_vars: scope_vars, &block)
     end
   end
 end

--- a/lib/dashdog/dsl_context.rb
+++ b/lib/dashdog/dsl_context.rb
@@ -1,0 +1,43 @@
+module Dashdog
+  class DSLContext
+    def initialize
+      @boards = {'timeboards' => [], 'screenboards' => []}
+    end
+
+    def eval_dsl(dsl_file)
+      @_dsl_file = dsl_file
+      instance_eval(File.read(dsl_file), dsl_file)
+      @boards
+    end
+
+    private
+
+    def require(file)
+      boardfile = (file =~ %r|\A/|) ? file : File.expand_path(File.join(File.dirname(@_dsl_file), file))
+
+      if File.exist?(boardfile)
+        instance_eval(File.read(boardfile), boardfile)
+      elsif File.exist?(boardfile + '.rb')
+        instance_eval(File.read(boardfile + '.rb'), boardfile + '.rb')
+      else
+        Kernel.require(file)
+      end
+    end
+
+    def timeboard(value = nil, &block)
+      hash = Dslh.eval(
+        allow_empty_args: true,
+        &block)
+      hash['title'] = value
+      @boards['timeboards'] << hash
+    end
+
+    def screenboard(value = nil, &block)
+      hash = Dslh.eval(
+        allow_empty_args: true,
+        &block)
+      hash['board_title'] = value
+      @boards['screenboards'] << hash
+    end
+  end
+end

--- a/lib/dashdog/utils.rb
+++ b/lib/dashdog/utils.rb
@@ -7,8 +7,8 @@ module Dashdog
 
     def self.diff(hash1, hash2)
       Diffy::Diff.new(
-        JSON.pretty_generate(hash1),
-        JSON.pretty_generate(hash2),
+        JSON.pretty_generate(hash1) + "\n",
+        JSON.pretty_generate(hash2) + "\n",
         :diff => '-u'
       ).to_s(:color)
     end


### PR DESCRIPTION
Add the support of the following templates:

``` ruby
template "template 1" do
  read_only false
  board_bgtype "board_graph"
  original_title "my board"
  height context.height
  width "100%"
  template_variables []
  widgets []
  shared false
  title_edited true
end

template "template 2" do
  title_size 16
  title_align "left"
  title_text ""
  title true
end

screenboard "board1" do
  include_template "template 1", height: 80
end

screenboard "board2" do
  read_only false
  board_bgtype "board_graph"
  height 80
  width "100%"
  templated false
  widgets do |*|
    include_template "template 2"
    height 13
    tile_def do
      viz "timeseries"
      requests do |*|
        q "aws.dynamodb.provisioned_read_capacity_units{*}"
      end
      events []
    end
    width 47
    timeframe "1h"
    y 13
    x 10
    legend_size "0"
    type "timeseries"
    legend false
  end
end
```

Please marge if no problem 🙇 
