### PR TITLE
Diff json after sort

### DIFF
--- a/lib/dashdog/utils.rb
+++ b/lib/dashdog/utils.rb
@@ -7,8 +7,8 @@ module Dashdog
 
     def self.diff(hash1, hash2)
       Diffy::Diff.new(
-        JSON.pretty_generate(hash1) + "\n",
-        JSON.pretty_generate(hash2) + "\n",
+        JSON.pretty_generate(self.deep_sort_hash(hash1)) + "\n",
+        JSON.pretty_generate(self.deep_sort_hash(hash2)) + "\n",
         :diff => '-u'
       ).to_s(:color)
     end
@@ -30,6 +30,25 @@ module Dashdog
 
     def self.print_json(json)
       puts CodeRay.scan(json, :json).terminal
+    end
+
+    def self.deep_sort_hash(obj)
+      case obj
+      when Hash
+        new_hash = {}
+
+        obj.sort_by{|k, _| k.to_s }.each do |key, value|
+          new_hash[key] = self.deep_sort_hash(value)
+        end
+
+        new_hash
+      when Array
+        obj.map do |value|
+          self.deep_sort_hash(value)
+        end
+      else
+        obj
+      end
     end
   end
 end


### PR DESCRIPTION
If json is not sorted, the keys order difference is output:

```
[Dry run] Update the screenboard 'test2'
 {
   "read_only": false,
-  "board_title": "test2",
   "board_bgtype": "board_graph",
   "height": 80,
   "width": "100%",
   "widgets": [
     {
       "title_size": 16,
-      "title": true,
       "title_align": "left",
       "title_text": "",
+      "title": true,
       "height": 13,
       "tile_def": {
         "viz": "timeseries",
       "width": 47,
       "timeframe": "1h",
       "y": 13,
-      "x": 10,
+      "x": 11,
       "legend_size": "0",
       "type": "timeseries",
       "legend": false
     }
   ],
+  "board_title": "test2",
   "id": 6927
 }
```

When sort the json, output as follows:

```
[Dry run] Update the screenboard 'test2'
       "title_text": "",
       "type": "timeseries",
       "width": 47,
-      "x": 10,
+      "x": 11,
       "y": 13
     }
   ],
```
