### PR TITLE
'delete timeboard' API returns 204 when the deletion was successful

### DIFF
--- a/lib/dashdog/client.rb
+++ b/lib/dashdog/client.rb
@@ -45,7 +45,7 @@ module Dashdog
 
     def delete_timeboard(id)
       ret = @api.delete_dashboard(id)
-      raise RuntimeError, ret[1]['errors'] if ret[0] != '200'
+      raise RuntimeError, ret[1]['errors'] if ret[0] != '204'
     end
 
     def create_screenboard(sb)


### PR DESCRIPTION
Hello, there!

When I called `Dashdog::Client#delete_timeboard`, a RuntimeError has occured in spite of deletion of the dashboard successfully.
It seems that `@api.delete_dashboard(id)` returns `[204, {}]`, so I fixed it.
