### PR TITLE
Exclude 'created_by' key because it is always overwritten in owner info of API key

### DIFF
--- a/lib/dashdog/actions.rb
+++ b/lib/dashdog/actions.rb
@@ -38,8 +38,10 @@ module Dashdog
           @client.create_timeboard(l) if dry_run.empty?
         else
           l['id'] = r['id']
-          r.delete('created')
-          r.delete('modified')
+          ['created', 'modified', 'created_by'].each do |field|
+            r.delete(field)
+            l.delete(field)
+          end
           if l == r
             info("#{dry_run}No changes '#{l['title']}'")
           else
@@ -66,8 +68,10 @@ module Dashdog
           @client.create_screenboard(l) if dry_run.empty?
         else
           l['id'] = r['id']
-          r.delete('created')
-          r.delete('modified')
+          ['created', 'modified', 'created_by'].each do |field|
+            r.delete(field)
+            l.delete(field)
+          end
           widgets = r['widgets'] || []
           r['widgets'] = []
           widgets.each do |wd|

--- a/lib/dashdog/converter.rb
+++ b/lib/dashdog/converter.rb
@@ -1,6 +1,6 @@
 require 'dslh'
 
-DELETE_KEYS = ['id', 'board_title', 'created', 'modified']
+DELETE_KEYS = ['id', 'board_title', 'created', 'modified', 'created_by']
 
 module Dashdog
   class Converter


### PR DESCRIPTION
日本語で失礼します。

created_by（タイムボード・スクリーンボードの作成者）情報が、apply毎に常にAPI keyの所有者で上書きされるため、このフィールドをdashdog管理から外すようにしました。
（ついでにcreated_byのユーザのroleとかも見れるようになってしまってて色々危なそうなのでいっその事・・・という気持ちです）

よろしくお願いします。