### PR TITLE
Stop warning when execute `dashdog apply`

### DIFF
--- a/lib/dashdog/cli.rb
+++ b/lib/dashdog/cli.rb
@@ -18,7 +18,7 @@ module Dashdog
     end
 
     desc "apply", "Apply the dashboard configurations"
-    option :dry_run, aliases: '-d', desc: 'Dry run (Only output the difference)', type: :string, default: false
+    option :dry_run, aliases: '-d', desc: 'Dry run (Only display the difference)', type: :boolean, default: false
     def apply
       @actions.apply(options)
     end


### PR DESCRIPTION
Hi there.

When I execute `dashdog apply` command, it always show me this warn: 

```
Expected string default value for '--dry-run'; got false (boolean)
```

I thought it is unnecessary to the `--dry-run` option take any arguments.
Regards ;)