### PR TITLE
Add '--ignore-exists' to apply command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,13 @@ Usage:
   dashdog apply
 
 Options:
-  -d, [--dry-run], [--no-dry-run]      # Dry run (Only display the difference)
-  -f, [--file=FILE]                    # Configuration file
-                                       # Default: Boardfile
-      [--color], [--no-color]          # Disable colorize
-                                       # Default: true
-  -e, [--exclude-title=EXCLUDE_TITLE]  # Exclude patterns of title
+  -d, [--dry-run], [--no-dry-run]            # Dry run (Only display the difference)
+      [--force-create], [--no-force-create]  # Force to create new dashboard
+  -f, [--file=FILE]                          # Configuration file
+                                             # Default: Boardfile
+      [--color], [--no-color]                # Disable colorize
+                                             # Default: true
+  -e, [--exclude-title=EXCLUDE_TITLE]        # Exclude patterns of title
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Usage:
   dashdog apply
 
 Options:
-  -d, [--dry-run], [--no-dry-run]            # Dry run (Only display the difference)
-      [--force-create], [--no-force-create]  # Force to create new dashboard
-  -f, [--file=FILE]                          # Configuration file
-                                             # Default: Boardfile
-      [--color], [--no-color]                # Disable colorize
-                                             # Default: true
-  -e, [--exclude-title=EXCLUDE_TITLE]        # Exclude patterns of title
+  -d, [--dry-run], [--no-dry-run]              # Dry run (Only display the difference)
+      [--ignore-exists], [--no-ignore-exists]  # Create new dashboards ignoring existing boards
+  -f, [--file=FILE]                            # Configuration file
+                                               # Default: Boardfile
+      [--color], [--no-color]                  # Disable colorize
+                                               # Default: true
+  -e, [--exclude-title=EXCLUDE_TITLE]          # Exclude patterns of title
 ```
 
 ## Development

--- a/lib/dashdog/actions.rb
+++ b/lib/dashdog/actions.rb
@@ -34,7 +34,7 @@ module Dashdog
       local.each do |l|
         next if !options['exclude_title'].nil? && l['title'].match(options['exclude_title'])
         r = _choice_by_title(remote, l['title'])
-        if r.nil?
+        if r.nil? || options['force_create']
           info("#{dry_run}Create the new timeboard '#{l['title']}'")
           @client.create_timeboard(l) if dry_run.empty?
         else
@@ -54,7 +54,7 @@ module Dashdog
       end
 
       remote.each do |r|
-        next if !options['exclude_title'].nil? && r['title'].match(options['exclude_title'])
+        next if (!options['exclude_title'].nil? && r['title'].match(options['exclude_title'])) || options['force_create']
         if _choice_by_title(local, r['title']).nil?
           warn("#{dry_run}Delete the timeboard '#{r['title']}'")
           @client.delete_timeboard(r['id']) if dry_run.empty?
@@ -66,7 +66,7 @@ module Dashdog
       local.each do |l|
         next if !options['exclude_title'].nil? && l['title'].match(options['exclude_title'])
         r = _choice_by_title(remote, l['board_title'])
-        if r.nil?
+        if r.nil? || options['force_create']
           info("#{dry_run}Create the new screenboards '#{l['board_title']}'")
           @client.create_screenboard(l) if dry_run.empty?
         else
@@ -93,7 +93,7 @@ module Dashdog
       end
 
       remote.each do |r|
-        next if !options['exclude_title'].nil? && r['title'].match(options['exclude_title'])
+        next if (!options['exclude_title'].nil? && r['title'].match(options['exclude_title'])) || options['force_create']
         if _choice_by_title(local, r['board_title']).nil?
           warn("#{dry_run}Delete the screenboard '#{r['board_title']}'")
           @client.delete_screenboard(r['id']) if dry_run.empty?

--- a/lib/dashdog/actions.rb
+++ b/lib/dashdog/actions.rb
@@ -34,7 +34,7 @@ module Dashdog
       local.each do |l|
         next if !options['exclude_title'].nil? && l['title'].match(options['exclude_title'])
         r = _choice_by_title(remote, l['title'])
-        if r.nil? || options['force_create']
+        if r.nil? || options['ignore_exists']
           info("#{dry_run}Create the new timeboard '#{l['title']}'")
           @client.create_timeboard(l) if dry_run.empty?
         else
@@ -54,7 +54,7 @@ module Dashdog
       end
 
       remote.each do |r|
-        next if (!options['exclude_title'].nil? && r['title'].match(options['exclude_title'])) || options['force_create']
+        next if (!options['exclude_title'].nil? && r['title'].match(options['exclude_title'])) || options['ignore_exists']
         if _choice_by_title(local, r['title']).nil?
           warn("#{dry_run}Delete the timeboard '#{r['title']}'")
           @client.delete_timeboard(r['id']) if dry_run.empty?
@@ -66,7 +66,7 @@ module Dashdog
       local.each do |l|
         next if !options['exclude_title'].nil? && l['title'].match(options['exclude_title'])
         r = _choice_by_title(remote, l['board_title'])
-        if r.nil? || options['force_create']
+        if r.nil? || options['ignore_exists']
           info("#{dry_run}Create the new screenboards '#{l['board_title']}'")
           @client.create_screenboard(l) if dry_run.empty?
         else
@@ -93,7 +93,7 @@ module Dashdog
       end
 
       remote.each do |r|
-        next if (!options['exclude_title'].nil? && r['title'].match(options['exclude_title'])) || options['force_create']
+        next if (!options['exclude_title'].nil? && r['title'].match(options['exclude_title'])) || options['ignore_exists']
         if _choice_by_title(local, r['board_title']).nil?
           warn("#{dry_run}Delete the screenboard '#{r['board_title']}'")
           @client.delete_screenboard(r['id']) if dry_run.empty?

--- a/lib/dashdog/cli.rb
+++ b/lib/dashdog/cli.rb
@@ -19,8 +19,8 @@ module Dashdog
     end
 
     desc "apply", "Apply the dashboard configurations"
-    option :dry_run, aliases: '-d', desc: 'Dry run (Only display the difference)', type: :boolean, default: false
-    option :force_create,           desc: 'Force to create new dashboard',         type: :boolean, default: false
+    option :dry_run, aliases: '-d', desc: 'Dry run (Only display the difference)',          type: :boolean, default: false
+    option :ignore_exists,          desc: 'Create new dashboards ignoring existing boards', type: :boolean, default: false
     def apply
       @actions.apply(options)
     end

--- a/lib/dashdog/cli.rb
+++ b/lib/dashdog/cli.rb
@@ -13,13 +13,14 @@ module Dashdog
 
     desc "export", "Export the dashboard configurations"
     option :write, aliases: '-w', desc: 'Write the configuration to the file', type: :boolean, default: false
-    option :split, desc: 'Split configuration file', type: :boolean, default: false
+    option :split,                desc: 'Split configuration file',            type: :boolean, default: false
     def export
       @actions.export(options)
     end
 
     desc "apply", "Apply the dashboard configurations"
     option :dry_run, aliases: '-d', desc: 'Dry run (Only display the difference)', type: :boolean, default: false
+    option :force_create,           desc: 'Force to create new dashboard',         type: :boolean, default: false
     def apply
       @actions.apply(options)
     end


### PR DESCRIPTION
Hello,

I implemented '--ignore-exists' option in `apply` command.
When this option is enabled, `dashdog apply` creates new dashboards ignoring existing dashboards.

Why do I add this option?
I think we do not need protect dashboard settings by us because datadog dashboards can not affect to decrease the level of services.
So I think we are had to be able to select to manage/neglect the state of the datadog dashboards.
